### PR TITLE
Specify upper bound for base16-bytestring

### DIFF
--- a/hex-text/hex-text.cabal
+++ b/hex-text/hex-text.cabal
@@ -32,7 +32,7 @@ library
   hs-source-dirs: src
   build-depends:
       base >=4.7 && <5
-    , base16-bytestring
+    , base16-bytestring <1.0
     , bytestring
     , text
   exposed-modules:


### PR DESCRIPTION
A new version released a few weeks ago breaks the build, specify upper
bound to unbreak it.