### PR TITLE
Add support for `text` 2.0

### DIFF
--- a/hex-text/hex-text.cabal
+++ b/hex-text/hex-text.cabal
@@ -34,7 +34,7 @@ common base
         base ^>= 4.9 || ^>= 4.10 || ^>= 4.11 || ^>= 4.12 || ^>= 4.13 || ^>= 4.14 || ^>= 4.15 || ^>= 4.16
       , base16-bytestring ^>= 1.0
       , bytestring ^>= 0.10 || ^>= 0.11
-      , text ^>= 1.2
+      , text >= 1.2
 
 library
     import: base


### PR DESCRIPTION
This is a one-character PR that allows this library to be used with newer versions of `text`. After some manual testing it seems to work just fine.