### PR TITLE
Make it build with ghc 9.10

### DIFF
--- a/hex-text/hex-text.cabal
+++ b/hex-text/hex-text.cabal
@@ -31,10 +31,10 @@ common base
         BlockArguments
         NoImplicitPrelude
     build-depends:
-      , base ^>= 4.16 || ^>= 4.17 || ^>= 4.18
+      , base >= 4.16 && < 4.21
       , base16-bytestring ^>= 1.0.2
-      , bytestring ^>= 0.11.4
-      , text ^>= 1.2.5 || ^>= 2.0
+      , bytestring ^>= 0.11.4 || ^>= 0.12
+      , text ^>= 1.2.5 || ^>= 2.0 || ^>= 2.1
 
 library
     import: base


### PR DESCRIPTION
This was needed to build a rather large project with `ghc-9.8`.

Would greatly appreciate these changes were propagated to Hackage via a metadata update.